### PR TITLE
Release 0.3.1

### DIFF
--- a/artifacts.gradle
+++ b/artifacts.gradle
@@ -1,4 +1,4 @@
-def commonArtifactVersion = "0.3"
+def commonArtifactVersion = "0.3.1"
 ext {
     artifactVersions = [
             data: commonArtifactVersion,

--- a/data/src/main/java/calendartools/data/WeeklyChecklistFactory.java
+++ b/data/src/main/java/calendartools/data/WeeklyChecklistFactory.java
@@ -69,7 +69,7 @@ public class WeeklyChecklistFactory {
 	public void offset(int offset) {
 		boolean reverse = offset < 0;
 		if (reverse) {
-			offset = (offset == Integer.MIN_VALUE) ? Integer.MAX_VALUE : -offset;
+			offset = (offset == Integer.MIN_VALUE) ? 5 : -offset;
 		}
 		// Normalize the Offset
 		if (offset >= 7) {offset %= 7;}

--- a/data/src/main/java/calendartools/data/WeeklyChecklistFactory.java
+++ b/data/src/main/java/calendartools/data/WeeklyChecklistFactory.java
@@ -60,4 +60,31 @@ public class WeeklyChecklistFactory {
 		}
 	}
 	
+	/** Translate the days of the week by a given offset.
+	 *  - Normalizes the Offset before applying any shift on the data (divides by 7).
+	 *  - An Offset of 1 shifts Monday into first day in the checklist data.
+	 *  - Negative 1 Offset shifts Saturday into the first day.
+	 * @param offset The offset to be applied to the weekly checklist data.
+	 */
+	public void offset(int offset) {
+		boolean reverse = offset < 0;
+		if (reverse) {
+			offset = (offset == Integer.MIN_VALUE) ? Integer.MAX_VALUE : -offset;
+		}
+		// Normalize the Offset
+		if (offset >= 7) {offset %= 7;}
+		// Zero Offset has no effect
+		if (offset == 0) return;
+		// A Reverse direction shift is the same as this
+		if (reverse)
+			offset = 7 - offset;
+		// Copy Array segments before overwriting
+		var seg0 = Arrays.copyOfRange(array, 0, offset);
+		var seg6 = Arrays.copyOfRange(array, offset, 7);
+		// Overwrite the array from the two segments
+		for (byte i = 0; i < array.length; i++) {
+			array[i] = (i < seg6.length) ? seg6[i]: seg0[i - seg6.length];
+		}
+	}
+	
 }

--- a/data/src/test/java/calendartools/data/WeeklyChecklistFactoryTest.java
+++ b/data/src/test/java/calendartools/data/WeeklyChecklistFactoryTest.java
@@ -155,4 +155,18 @@ public class WeeklyChecklistFactoryTest {
         assertEquals((byte) 0, mWednesday.get().mData);
     }
     
+    @Test
+    public void testOffset_Wednesday_MinValue_ShiftsToMonday() {
+        mWednesday.offset(Integer.MIN_VALUE);
+        assertFalse(mWednesday.toggle(Calendar.MONDAY));
+        assertEquals((byte) 0, mWednesday.get().mData);
+    }
+    
+    @Test
+    public void testOffset_Wednesday_MaxValue_ShiftsToTuesday() {
+        mWednesday.offset(Integer.MAX_VALUE);
+        assertFalse(mWednesday.toggle(Calendar.TUESDAY));
+        assertEquals((byte) 0, mWednesday.get().mData);
+    }
+    
 }

--- a/data/src/test/java/calendartools/data/WeeklyChecklistFactoryTest.java
+++ b/data/src/test/java/calendartools/data/WeeklyChecklistFactoryTest.java
@@ -1,11 +1,14 @@
 package calendartools.data;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Calendar;
 
 public class WeeklyChecklistFactoryTest {
     
@@ -21,12 +24,18 @@ public class WeeklyChecklistFactoryTest {
      */
     WeeklyChecklist allTrue;
     
+    /** A WeeklyChecklist Factory with only Wednesday set to True.
+     */
+    WeeklyChecklistFactory mWednesday;
+    
     @Before
     public void testSetup() {
         mInstance = new WeeklyChecklistFactory();
         allTrue = new WeeklyChecklist(true);
         allTrueInstance = new WeeklyChecklistFactory();
         allTrueInstance.fromChecklist(allTrue);
+        mWednesday = new WeeklyChecklistFactory();
+        mWednesday.toggle(Calendar.WEDNESDAY);
     }
     
     @Test
@@ -40,6 +49,17 @@ public class WeeklyChecklistFactoryTest {
     public void testToggle_AllTrue_7Days_ReturnsFalseAll7() {
         for (byte i = 1; i < 8; i++) {
             assertFalse(allTrueInstance.toggle(i));
+        }
+    }
+    
+    @Test
+    public void testToggle_Wednesday_7Days_ReturnsFalseOnWednesday() {
+        for (byte i = 1; i < 8; i++) {
+            if (i == Calendar.WEDNESDAY) {
+                assertFalse(mWednesday.toggle(i));
+            } else {
+                assertTrue(mWednesday.toggle(i));
+            }
         }
     }
     
@@ -64,11 +84,75 @@ public class WeeklyChecklistFactoryTest {
     }
     
     @Test
+    public void testClear_Wednesday() {
+        mWednesday.clear();
+        for (byte i = 0; i < 7; i++) {
+            assertFalse(mInstance.array[i]);
+        }
+    }
+    
+    @Test
     public void testClear_AllTrue() {
         allTrueInstance.clear();
         for (byte i = 0; i < 7; i++) {
             assertFalse(allTrueInstance.array[i]);
         }
+    }
+    
+    @Test
+    public void testOffset_Wednesday_1_ShiftsToTuesday() {
+        mWednesday.offset(1);
+        assertFalse(mWednesday.toggle(Calendar.TUESDAY));
+        assertEquals((byte) 0, mWednesday.get().mData);
+    }
+    
+    @Test
+    public void testOffset_Wednesday_2_ShiftsToMonday() {
+        mWednesday.offset(2);
+        assertFalse(mWednesday.toggle(Calendar.MONDAY));
+        assertEquals((byte) 0, mWednesday.get().mData);
+    }
+    
+    @Test
+    public void testOffset_Wednesday_10_ShiftsToSunday() {
+        mWednesday.offset(10);
+        assertFalse(mWednesday.toggle(Calendar.SUNDAY));
+        assertEquals((byte) 0, mWednesday.get().mData);
+    }
+    
+    @Test
+    public void testOffset_Wednesday_Negative1_ShiftsToThursday() {
+        mWednesday.offset(-1);
+        assertFalse(mWednesday.toggle(Calendar.THURSDAY));
+        assertEquals((byte) 0, mWednesday.get().mData);
+    }
+    
+    @Test
+    public void testOffset_Wednesday_Negative2_ShiftsToFriday() {
+        mWednesday.offset(-2);
+        assertFalse(mWednesday.toggle(Calendar.FRIDAY));
+        assertEquals((byte) 0, mWednesday.get().mData);
+    }
+    
+    @Test
+    public void testOffset_Wednesday_6_ShiftsToThursday() {
+        mWednesday.offset(6);
+        assertFalse(mWednesday.toggle(Calendar.THURSDAY));
+        assertEquals((byte) 0, mWednesday.get().mData);
+    }
+    
+    @Test
+    public void testOffset_Wednesday_7_DoesNothing() {
+        mWednesday.offset(7);
+        assertFalse(mWednesday.toggle(Calendar.WEDNESDAY));
+        assertEquals((byte) 0, mWednesday.get().mData);
+    }
+    
+    @Test
+    public void testOffset_Wednesday_0_DoesNothing() {
+        mWednesday.offset(0);
+        assertFalse(mWednesday.toggle(Calendar.WEDNESDAY));
+        assertEquals((byte) 0, mWednesday.get().mData);
     }
     
 }

--- a/yearplanner/src/main/java/calendartools/yearplanner/YearPlanner.java
+++ b/yearplanner/src/main/java/calendartools/yearplanner/YearPlanner.java
@@ -187,7 +187,7 @@ public class YearPlanner {
     
     /** Obtain an Array containing the Days of the Month for a given Week Number.
      * @param weekNumber The number of the Week.
-     * @return A Byte Array containing 7 numbers, from Monday to Sunday.
+     * @return A Byte Array containing 7 numbers, from Sunday to Saturday.
      */
     public byte[] getDayArray(
         final byte weekNumber
@@ -195,6 +195,41 @@ public class YearPlanner {
         var cal = new Calendar.Builder()
                 .setFields(Calendar.YEAR, mYear, Calendar.WEEK_OF_YEAR, weekNumber)
                 .build();
+        byte[] dayArray = new byte[7];
+        dayArray[0] = (byte) cal.get(Calendar.DAY_OF_MONTH);  // Sunday DayOfMonth
+        var diff = 0;
+        for (byte i = 1; i < 7; i++) {
+            byte inc = (byte) (dayArray[i - 1] + 1);
+            if (inc <= 28) {
+                dayArray[i] = inc;
+                diff++;
+            } else {
+                cal.add(Calendar.DAY_OF_YEAR, diff + 1);
+                diff = 0;
+                dayArray[i] = (byte) cal.get(Calendar.DAY_OF_MONTH);
+            }
+        }
+        return dayArray;
+    }
+    
+    /** Obtain an Array containing the Days of the Month for a given Week Number, with WeekOffset.
+     * @param weekNumber The number of the Week.
+     * @param weekOffset The number of days to offset, such as shifting the week to start on monday (1), or wednesday (3).
+     * @return A Byte Array containing 7 numbers, the week that was requested.
+     */
+    public byte[] getDayArray(
+        final byte weekNumber,
+        final byte weekOffset
+    ) throws IllegalArgumentException {
+        // Week Offset must be between -7 and 7 days.
+        if (-7 > weekOffset || weekOffset > 7)
+            throw new IllegalArgumentException("Invalid WeekOffset: " + weekOffset);
+        var cal = new Calendar.Builder()
+            .setFields(Calendar.YEAR, mYear, Calendar.WEEK_OF_YEAR, weekNumber)
+            .build();   // Currently, Sunday is the DayOfWeek
+        // Shift the Calendar by the Offset
+        cal.add(Calendar.DAY_OF_MONTH, weekOffset);
+        // Create the DayArray, using same process as without the WeekOffset, from here on out.
         byte[] dayArray = new byte[7];
         dayArray[0] = (byte) cal.get(Calendar.DAY_OF_MONTH);
         var diff = 0;

--- a/yearplanner/src/main/java/calendartools/yearplanner/YearPlanner.java
+++ b/yearplanner/src/main/java/calendartools/yearplanner/YearPlanner.java
@@ -52,6 +52,18 @@ public class YearPlanner {
         return (byte) cal.get(Calendar.WEEK_OF_YEAR);
     }
     
+    /** Determine the offset for the start of the given year.
+     *  - Value Range: 1 - 7, corresponding with Calendar.SUNDAY ... Calendar.SATURDAY
+     * @param year The Year to calculate for.
+     * @return The Day of Week that the year starts on. See Calendar.SUNDAY, etc.
+     */
+    public static byte getWeekOffset(final int year) {
+        Calendar cal = new Calendar.Builder()
+            .setFields(Calendar.YEAR, year, Calendar.DAY_OF_YEAR, 1)
+            .build();
+        return (byte) cal.get(Calendar.DAY_OF_WEEK);
+    }
+    
     /** The Year that this Class will be used for.
      */
     public final short mYear;

--- a/yearplanner/src/main/java/calendartools/yearplanner/YearPlanner.java
+++ b/yearplanner/src/main/java/calendartools/yearplanner/YearPlanner.java
@@ -53,15 +53,17 @@ public class YearPlanner {
     }
     
     /** Determine the offset for the start of the given year.
-     *  - Value Range: 1 - 7, corresponding with Calendar.SUNDAY ... Calendar.SATURDAY
+     *  - Value Range: 0 - 6, corresponding with Calendar.SUNDAY ... Calendar.SATURDAY
      * @param year The Year to calculate for.
-     * @return The Day of Week that the year starts on. See Calendar.SUNDAY, etc.
+     * @return The Offset from a week that starts on Sunday, because Sunday is lowest Calendar constant.
      */
     public static byte getWeekOffset(final int year) {
-        Calendar cal = new Calendar.Builder()
+        final int dayOfWeek = new Calendar.Builder()
             .setFields(Calendar.YEAR, year, Calendar.DAY_OF_YEAR, 1)
-            .build();
-        return (byte) cal.get(Calendar.DAY_OF_WEEK);
+            .build()
+            .get(Calendar.DAY_OF_WEEK);
+        // If the Day of Week is Sunday, the Offset is zero.
+        return (byte) (dayOfWeek - 1);
     }
     
     /** The Year that this Class will be used for.

--- a/yearplanner/src/main/java/calendartools/yearplanner/YearPlanner.java
+++ b/yearplanner/src/main/java/calendartools/yearplanner/YearPlanner.java
@@ -193,7 +193,7 @@ public class YearPlanner {
      */
     public byte[] getDayArray(
         final byte weekNumber
-    ) throws IllegalArgumentException {
+    ) {
         var cal = new Calendar.Builder()
                 .setFields(Calendar.YEAR, mYear, Calendar.WEEK_OF_YEAR, weekNumber)
                 .build();
@@ -216,21 +216,18 @@ public class YearPlanner {
     
     /** Obtain an Array containing the Days of the Month for a given Week Number, with WeekOffset.
      * @param weekNumber The number of the Week.
-     * @param weekOffset The number of days to offset, such as shifting the week to start on monday (1), or wednesday (3).
+     * @param weekdayOffset The number of days to offset, such as shifting the week to start on monday (1), or wednesday (3).
      * @return A Byte Array containing 7 numbers, the week that was requested.
      */
     public byte[] getDayArray(
         final byte weekNumber,
-        final byte weekOffset
-    ) throws IllegalArgumentException {
-        // Week Offset must be between -7 and 7 days.
-        if (-7 > weekOffset || weekOffset > 7)
-            throw new IllegalArgumentException("Invalid WeekOffset: " + weekOffset);
+        final byte weekdayOffset
+    ) {
         var cal = new Calendar.Builder()
             .setFields(Calendar.YEAR, mYear, Calendar.WEEK_OF_YEAR, weekNumber)
             .build();   // Currently, Sunday is the DayOfWeek
         // Shift the Calendar by the Offset
-        cal.add(Calendar.DAY_OF_MONTH, weekOffset);
+        cal.add(Calendar.DAY_OF_MONTH, weekdayOffset);
         // Create the DayArray, using same process as without the WeekOffset, from here on out.
         byte[] dayArray = new byte[7];
         dayArray[0] = (byte) cal.get(Calendar.DAY_OF_MONTH);

--- a/yearplanner/src/test/java/calendartools/yearplanner/YearPlannerStaticTest.java
+++ b/yearplanner/src/test/java/calendartools/yearplanner/YearPlannerStaticTest.java
@@ -55,37 +55,37 @@ public final class YearPlannerStaticTest {
     
     @Test
     public void test_GetWeekOffset_2034_ReturnsSunday() {
-        assertEquals(Calendar.SUNDAY, getWeekOffset(2034));
+        assertEquals(Calendar.SUNDAY - 1, getWeekOffset(2034));
     }
     
     @Test
     public void test_GetWeekOffset_2024_ReturnsMonday() {
-        assertEquals(Calendar.MONDAY, getWeekOffset(2024));
+        assertEquals(Calendar.MONDAY - 1, getWeekOffset(2024));
     }
     
     @Test
     public void test_GetWeekOffset_2024_ReturnsTuesday() {
-        assertEquals(Calendar.TUESDAY, getWeekOffset(2030));
+        assertEquals(Calendar.TUESDAY - 1, getWeekOffset(2030));
     }
     
     @Test
     public void test_GetWeekOffset_2025_ReturnsWednesday() {
-        assertEquals(Calendar.WEDNESDAY, getWeekOffset(2025));
+        assertEquals(Calendar.WEDNESDAY - 1, getWeekOffset(2025));
     }
     
     @Test
     public void test_GetWeekOffset_2026_ReturnsThursday() {
-        assertEquals(Calendar.THURSDAY, getWeekOffset(2026));
+        assertEquals(Calendar.THURSDAY - 1, getWeekOffset(2026));
     }
     
     @Test
     public void test_GetWeekOffset_2026_ReturnsFriday() {
-        assertEquals(Calendar.FRIDAY, getWeekOffset(2027));
+        assertEquals(Calendar.FRIDAY - 1, getWeekOffset(2027));
     }
     
     @Test
     public void test_GetWeekOffset_2028_ReturnsSaturday() {
-        assertEquals(Calendar.SATURDAY, getWeekOffset(2028));
+        assertEquals(Calendar.SATURDAY - 1, getWeekOffset(2028));
     }
     
 }

--- a/yearplanner/src/test/java/calendartools/yearplanner/YearPlannerStaticTest.java
+++ b/yearplanner/src/test/java/calendartools/yearplanner/YearPlannerStaticTest.java
@@ -4,8 +4,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static calendartools.yearplanner.YearPlanner.getDayNumber;
 import static calendartools.yearplanner.YearPlanner.getWeekNumber;
+import static calendartools.yearplanner.YearPlanner.getWeekOffset;
 
 import org.junit.Test;
+
+import java.util.Calendar;
 
 import calendartools.data.TestDataProvider;
 
@@ -48,6 +51,41 @@ public final class YearPlannerStaticTest {
     public void test_GetWeekNumber_LastDayOf2025_Returns1() {
         // Would be 53, but it wraps to 1.
         assertEquals(1, getWeekNumber(TestDataProvider.LastDayOf2025));
+    }
+    
+    @Test
+    public void test_GetWeekOffset_2034_ReturnsSunday() {
+        assertEquals(Calendar.SUNDAY, getWeekOffset(2034));
+    }
+    
+    @Test
+    public void test_GetWeekOffset_2024_ReturnsMonday() {
+        assertEquals(Calendar.MONDAY, getWeekOffset(2024));
+    }
+    
+    @Test
+    public void test_GetWeekOffset_2024_ReturnsTuesday() {
+        assertEquals(Calendar.TUESDAY, getWeekOffset(2030));
+    }
+    
+    @Test
+    public void test_GetWeekOffset_2025_ReturnsWednesday() {
+        assertEquals(Calendar.WEDNESDAY, getWeekOffset(2025));
+    }
+    
+    @Test
+    public void test_GetWeekOffset_2026_ReturnsThursday() {
+        assertEquals(Calendar.THURSDAY, getWeekOffset(2026));
+    }
+    
+    @Test
+    public void test_GetWeekOffset_2026_ReturnsFriday() {
+        assertEquals(Calendar.FRIDAY, getWeekOffset(2027));
+    }
+    
+    @Test
+    public void test_GetWeekOffset_2028_ReturnsSaturday() {
+        assertEquals(Calendar.SATURDAY, getWeekOffset(2028));
     }
     
 }

--- a/yearplanner/src/test/java/calendartools/yearplanner/YearPlannerTest.java
+++ b/yearplanner/src/test/java/calendartools/yearplanner/YearPlannerTest.java
@@ -327,6 +327,42 @@ public final class YearPlannerTest {
     }
     
     @Test
+    public void test_GetDayArray_Offset1_CurrentYear2025_Week1() {
+        var result = mInstance.getDayArray((byte) 1, (byte) 1);
+        assertArrayEquals(
+            new byte[]{30, 31, 1, 2, 3, 4, 5},
+            result
+        );
+    }
+    
+    @Test
+    public void test_GetDayArray_Offset1_CurrentYear2025_Week18() {
+        var result = mInstance.getDayArray((byte) 18, (byte) 1);
+        assertArrayEquals(
+            new byte[]{28, 29, 30, 1, 2, 3, 4},
+            result
+        );
+    }
+    
+    @Test
+    public void test_GetDayArray_Offset3_CurrentYear2025_Week18() {
+        var result = mInstance.getDayArray((byte) 18, (byte) 3);
+        assertArrayEquals(
+            new byte[]{30, 1, 2, 3, 4, 5, 6},
+            result
+        );
+    }
+    
+    @Test
+    public void test_GetDayArray_Offset4_CurrentYear2025_Week18() {
+        var result = mInstance.getDayArray((byte) 18, (byte) 4);
+        assertArrayEquals(
+            new byte[]{1, 2, 3, 4, 5, 6, 7},
+            result
+        );
+    }
+    
+    @Test
     public void test_ValidateMonthDayPair_ZeroMonth() {
         assertFalse(mInstance.validateMonthDayPair(0, 1));
     }

--- a/yearplanner/src/test/java/calendartools/yearplanner/YearPlannerTest.java
+++ b/yearplanner/src/test/java/calendartools/yearplanner/YearPlannerTest.java
@@ -327,6 +327,26 @@ public final class YearPlannerTest {
     }
     
     @Test
+    public void test_GetDayArray_CurrentYear2025_Week0() {
+        var result = mInstance.getDayArray((byte) 0);
+        assertArrayEquals(
+            new byte[]{22, 23, 24, 25, 26, 27, 28},
+            result
+        );
+    }
+    
+    @Test
+    public void test_GetDayArray_CurrentYear2025_WeekNegative1() {
+        byte val = 0;
+        val -= 1;
+        var result = mInstance.getDayArray(val);
+        assertArrayEquals(
+            new byte[]{15, 16, 17, 18, 19, 20, 21},
+            result
+        );
+    }
+    
+    @Test
     public void test_GetDayArray_Offset1_CurrentYear2025_Week1() {
         var result = mInstance.getDayArray((byte) 1, (byte) 1);
         assertArrayEquals(
@@ -358,6 +378,15 @@ public final class YearPlannerTest {
         var result = mInstance.getDayArray((byte) 18, (byte) 4);
         assertArrayEquals(
             new byte[]{1, 2, 3, 4, 5, 6, 7},
+            result
+        );
+    }
+    
+    @Test
+    public void test_GetDayArray_Offset7_CurrentYear2025_Week18() {
+        var result = mInstance.getDayArray((byte) 18, (byte) 7);
+        assertArrayEquals(
+            new byte[]{4, 5, 6, 7, 8, 9, 10},
             result
         );
     }


### PR DESCRIPTION
## Yearplanner
Handling slightly more use cases, and clarifying potential differences between week numbering systems, such as those that start on sunday or monday, or even those that want to start on Wednesday.

A new static method `getWeekOffset` determines the Day of Week that a given year starts on.
 - Providing this method to reduce confusion around different week numbers and start dates.

Some additional modifications, such as method overloads are under consideration at the moment.
 - These are aimed at supporting different weekOffsets (Wednesday).
 - An overload of `getDayArray` is a high probability.

### Further Time Modelling
The purpose of this time model is to clear as much confusion about time as possible, and reduce it to numbers. Removing Months and Day of the Week information may be exactly what you need to get closer to a clear picture, a localized time coordinate that works better in your short-term planning calculations.

The YearPlanner is a bridge between large and small timescales. Have your long-term vision, and make the most of every week!